### PR TITLE
Allow building on Alpine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,8 +17,8 @@ if test x"$ac_cv_prog_LEX" = "x"; then
       AC_MSG_ERROR([lex is required])
 fi
 
-if test x"$ac_cv_prog_YACC" = "x"; then
-      AC_MSG_ERROR([yacc is required])
+if test x"$ac_cv_prog_YACC" != "xbison -y"; then
+      AC_MSG_ERROR([bison is required])
 fi
 
 dnl libseccomp
@@ -38,6 +38,10 @@ AC_TYPE_SIZE_T
 
 AC_FUNC_ERROR_AT_LINE
 AC_CHECK_FUNCS([memset strdup])
+
+AC_SEARCH_LIBS([argp_parse], [argp], [], [
+  AC_MSG_ERROR([unable to find the argp_parse() function])
+])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/generator.c
+++ b/src/generator.c
@@ -21,7 +21,6 @@
 #include "generator.h"
 #include "syscall-versions/syscall-versions.h"
 #include "errnos.h"
-#include "error.h"
 #include "libeasyseccomp_a-parser.h"
 #include "libeasyseccomp_a-lexer.h"
 #include <linux/types.h>

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -21,7 +21,6 @@
 #include "generator.h"
 
 #include <string.h>
-#include <error.h>
 #include <errno.h>
 
 char *

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <error.h>
+#include <err.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <argp.h>
@@ -157,7 +157,7 @@ main (int argc, char **argv)
 
   easyseccomp_ctx = easy_seccomp_make_ctx ();
   if (easyseccomp_ctx == NULL)
-    error (EXIT_FAILURE, errno, "create context");
+    err (EXIT_FAILURE, "create context");
 
   context.ctx = easyseccomp_ctx;
   context.input = stdin;
@@ -166,7 +166,7 @@ main (int argc, char **argv)
   argp_parse (&argp, argc, argv, 0, 0, &context);
 
   if (isatty (fileno (context.output)) && getenv ("FORCE_TTY") == NULL)
-    error (EXIT_FAILURE, 0, "I refuse to write to a tty.  Redirect the output");
+    errx (EXIT_FAILURE, "I refuse to write to a tty.  Redirect the output");
 
   ret = easy_seccomp_compile (context.ctx, context.input, context.output);
   if (ret < 0)

--- a/src/parser.y
+++ b/src/parser.y
@@ -21,7 +21,6 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <error.h>
 #include <stdlib.h>
 #include <argp.h>
 

--- a/src/seccomp_run.c
+++ b/src/seccomp_run.c
@@ -19,7 +19,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <error.h>
+#include <err.h>
 #include <errno.h>
 #include <syscall.h>
 #include <linux/filter.h>
@@ -49,21 +49,21 @@ main (int argc, char *argv[])
   int r;
 
   if (argc < 3)
-    error (EXIT_FAILURE, 0, "usage: %s seccomp.bpf COMMAND ...", argv[0]);
+    errx (EXIT_FAILURE, "usage: %s seccomp.bpf COMMAND ...", argv[0]);
 
   fd = open (argv[1], O_RDONLY | O_CLOEXEC);
   if (fd < 0)
-    error (EXIT_FAILURE, errno, "open `%s`", argv[1]);
+    err (EXIT_FAILURE, "open `%s`", argv[1]);
 
   r = fstat (fd, &st);
   if (r < 0)
-    error (EXIT_FAILURE, errno, "fstat `%s", argv[1]);
+    err (EXIT_FAILURE, "fstat `%s", argv[1]);
 
   if (st.st_size > 0)
     {
       addr = mmap (NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
       if (addr == MAP_FAILED)
-        error (EXIT_FAILURE, errno, "mmap");
+        err (EXIT_FAILURE, "mmap");
       size = st.st_size;
     }
   else
@@ -73,13 +73,13 @@ main (int argc, char *argv[])
         {
           addr = realloc (addr, size + 4096);
           if (addr == NULL)
-            error (EXIT_FAILURE, errno, "malloc");
+            err (EXIT_FAILURE, "malloc");
 
           do
             r = read (fd, addr + size, 4096);
           while (r < 0 && errno == EINTR);
           if (r < 0)
-            error (EXIT_FAILURE, errno, "read");
+            err (EXIT_FAILURE, "read");
           if (r == 0)
             break;
           size += r;
@@ -95,7 +95,7 @@ main (int argc, char *argv[])
       if (r == 0)
         r = syscall_seccomp (SECCOMP_SET_MODE_FILTER, 0, &seccomp_filter);
       if (r < 0)
-        error (EXIT_FAILURE, errno, "seccomp");
+        err (EXIT_FAILURE, "seccomp");
     }
 
   if (st.st_size == 0)
@@ -104,7 +104,7 @@ main (int argc, char *argv[])
     {
       r = munmap (addr, st.st_size);
       if (r < 0)
-        error (EXIT_FAILURE, errno, "munmap");
+        err (EXIT_FAILURE, "munmap");
     }
 
   for (argc = 2; argv[argc]; argc++)


### PR DESCRIPTION
Title.

Main changes are searching for [argp-standalone](https://github.com/ericonr/argp-standalone), using more common  `err`/`errx` instead  or `error`, and explicitly requiring `bison` as the yacc implementation.

The test suite isn't ported (but my target machine is aarch64, so the test suite isn't supported there anyway, and the main program seems to work).